### PR TITLE
Allow to set Tika server as URL

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -73,7 +73,7 @@ abstract class Client
      */
     public static function make($param1 = null, $param2 = null, $options = [])
     {
-        if (preg_match('/\.jar$/', func_get_arg(0)))
+        if (func_num_args() > 0 && preg_match('/\.jar$/', func_get_arg(0)))
         {
             return new CLIClient($param1, $param2);
         }

--- a/src/Clients/WebClient.php
+++ b/src/Clients/WebClient.php
@@ -40,6 +40,13 @@ class WebClient extends Client
     protected $port = 9998;
 
     /**
+     * Apache Tika server base URL
+     *
+     * @var string
+     */
+    protected $baseUrl = null;
+
+    /**
      * Number of retries on server error
      *
      * @var int
@@ -86,8 +93,6 @@ class WebClient extends Client
         }
 
         $this->setDownloadRemote(true);
-
-        $this->getVersion(); // exception if not running
     }
 
     /**
@@ -134,6 +139,30 @@ class WebClient extends Client
         $this->port = $port;
 
         return $this;
+    }
+
+    /**
+     * Gets the base URL
+     *
+     * @return string
+     */
+    public function getBaseUrl()
+    {
+        if ($this->baseUrl !== null) {
+            return $this->baseUrl;
+        } else {
+            return "http://{$this->host}:{$this->port}/";
+        }
+    }
+
+    /**
+     * Set the base URL
+     *
+     * @param string $baseUrl
+     */
+    public function setBaseUrl($baseUrl)
+    {
+        $this->baseUrl = $baseUrl;
     }
 
     /**
@@ -281,7 +310,7 @@ class WebClient extends Client
         }
 
         // cURL init and options
-        $options[CURLOPT_URL] = "http://{$this->host}:{$this->port}" . "/$resource";
+        $options[CURLOPT_URL] = rtrim($this->getBaseUrl(), '/') . "/$resource";
 
         // get the response and the HTTP status code
         list($response, $status) = $this->exec($options);


### PR DESCRIPTION
This makes it much easier to pass in the target host and port from an environment variable.

```php
<?php

require_once('vendor/autoload.php');

$client = \Vaites\ApacheTika\Client::make();
$client->setBaseUrl(getenv('TIKA_SERVER_URL'));
...
```