### PR TITLE
Reduce memory usage with fclose()

### DIFF
--- a/src/Clients/WebClient.php
+++ b/src/Clients/WebClient.php
@@ -342,6 +342,10 @@ class WebClient extends Client
         // get the response and the HTTP status code
         list($response, $status) = $this->exec($options);
 
+        if ($file && is_resource($options[CURLOPT_INFILE])){
+            fclose($options[CURLOPT_INFILE]);
+        }
+
         // request completed successfully
         if($status == 200)
         {
@@ -371,6 +375,7 @@ class WebClient extends Client
         {
             $this->error($status, $resource);
         }
+
 
         return $response;
     }

--- a/src/Clients/WebClient.php
+++ b/src/Clients/WebClient.php
@@ -376,7 +376,6 @@ class WebClient extends Client
             $this->error($status, $resource);
         }
 
-
         return $response;
     }
 


### PR DESCRIPTION
When indexing multiple files, for example within a for loop, there is excessive memory usage which could cause PHP to run into memory issues.

By adding fclose() on the file resource, after performing the cURL request, memory usage can be decreased a lot.

On 10 iterations with the file `samples/sample5.pdf`
Without fclose():

```
Iteration 0
960M
Iteration 1
960M
Iteration 2
960M
Iteration 3
960M
Iteration 4
960M
Iteration 5
960M
Iteration 6
960M
Iteration 7
960M
Iteration 8
960M
Iteration 9
960M
Iteration 10
960M
``` 

And after adding fclose():

```
Iteration 0
192M
Iteration 1
192M
Iteration 2
192M
Iteration 3
192M
Iteration 4
192M
Iteration 5
192M
Iteration 6
192M
Iteration 7
192M
Iteration 8
192M
Iteration 9
192M
Iteration 10
192M```