### PR TITLE
Fix fetcher name checking, simplify transition from Tika 1.x to 2.x

### DIFF
--- a/src/Clients/WebClient.php
+++ b/src/Clients/WebClient.php
@@ -232,11 +232,6 @@ class WebClient extends Client
      */
     public function setFetcherName(string $fetcherName): self
     {
-        if(!in_array($fetcherName, ['FileSystemFetcher', 'HttpFetcher', 'S3Fetcher', 'GCSFetcher', 'SolrFetcher']))
-        {
-            throw new Exception("Fetcher name $fetcherName is invalid, see https://cwiki.apache.org/confluence/display/TIKA/tika-pipes");
-        }
-
         $this->fetcherName = $fetcherName;
 
         return $this;
@@ -662,13 +657,10 @@ class WebClient extends Client
         {
             if($this->fetcherName)
             {
-                $headers[] = "fetcherName:$this->fetcherName";
-                $headers[] = "fetchKey:$file";
+                $headers[] = "fetcherName: $this->fetcherName";
+                $headers[] = "fetchKey: $file";
             }
-            else
-            {
-                $headers[] = "fileUrl:$file";
-            }
+            $headers[] = "fileUrl: $file";
         }
 
         switch($type)


### PR DESCRIPTION
- Fix #34 by not limiting fetcher names
- Use the Tika 1.x `fileUrl` header in parallel with the new `fetcherName`/`fetcherKey` (when enabled).

The second change allows for a smooth/rolling migration from Tika 1.x to Tika 2.x servers. Sending the extra `fileUrl` header in Tika 2.x is not a problem.