### PR TITLE
Fix extract text from url with DownloadRemote

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -634,6 +634,7 @@ abstract class Client
 
         curl_setopt($ch, CURLOPT_FILE, $fp);
         curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_exec($ch);
 
         if(curl_errno($ch))

--- a/src/Client.php
+++ b/src/Client.php
@@ -531,12 +531,17 @@ abstract class Client
         if(in_array($type, ['detectors', 'mime-types', 'parsers', 'version']))
         {
             //
-        } 
+        }
         // invalid local file
         elseif($file !== null && !preg_match('/^http/', $file) && !file_exists($file))
         {
             throw new Exception("File $file can't be opened");
-        } 
+        }
+        // download remote file if required only for integrated downloader
+        elseif($file !== null && preg_match('/^http/', $file) && $this->downloadRemote)
+        {
+            $file = $this->downloadFile($file);
+        }
         // invalid remote file
         elseif($file !== null && preg_match('/^http/', $file))
         {
@@ -546,11 +551,6 @@ abstract class Client
             {
                 throw new Exception("File $file can't be opened", 2);
             }
-        } 
-        // download remote file if required only for integrated downloader
-        elseif($file !== null && preg_match('/^http/', $file) && $this->downloadRemote)
-        {
-            $file = $this->downloadFile($file);
         }
 
         return $file;


### PR DESCRIPTION
Hi, I found a potential bug when try to use Tika to parse URL's.
My code is the following, using TIKA v.2.9.x via docker:

```
<?php

require 'vendor\autoload.php';

$client = \Vaites\ApacheTika\Client::make('localhost', 9998);
$client->setDownloadRemote(true);

//it works
$document = $client->getText('./LIB0194021_A4-LHOV.pdf');

var_dump( $document );

//doesn't works
$document = $client->getText('https://arxiv.org/pdf/1910.13461.pdf');

var_dump( $document );

//doesn't works
$document = $client->getMainText('https://arxiv.org/archive/astro-ph');

var_dump( $document );
```

the error is the follow:
```

PHP Fatal error:  Uncaught Exception: Unprocessable document in C:\WORKAREA\Projects\cloudconversa\research\tika\vendor\vaites\php-apache-tika\src\Clients\WebClient.php:642
Stack trace:
#0 C:\WORKAREA\Projects\cloudconversa\research\tika\vendor\vaites\php-apache-tika\src\Clients\WebClient.php(556): Vaites\ApacheTika\Clients\WebClient->error()
#1 C:\WORKAREA\Projects\cloudconversa\research\tika\vendor\vaites\php-apache-tika\src\Client.php(389): Vaites\ApacheTika\Clients\WebClient->request()
#2 C:\WORKAREA\Projects\cloudconversa\research\tika\tika.php(12): Vaites\ApacheTika\Client->getMainText()
#3 {main}
  thrown in C:\WORKAREA\Projects\cloudconversa\research\tika\vendor\vaites\php-apache-tika\src\Clients\WebClient.php on line 642
```

this because on Client.php row 540 checks for "invalid remote file" before try to "download remote file if required only for integrated downloader".
I switched these two blocks.
Than I also added on row 637 the CURLOPT_FOLLOWLOCATION option to follow redirects and avoid errors when download URL has a 301.

Hope this can be useful. thank you!