### PR TITLE
fix deprecations for nullable parameters on PHP 8.4

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -109,7 +109,7 @@ abstract class Client
      * @return \Vaites\ApacheTika\Clients\CLIClient|\Vaites\ApacheTika\Clients\WebClient
      * @throws \Exception
      */
-    public static function make(string $param1 = null, $param2 = null, array $options = [], bool $check = true): Client
+    public static function make(?string $param1 = null, $param2 = null, array $options = [], bool $check = true): Client
     {
         if(preg_match('/\.jar$/', func_get_arg(0)))
         {
@@ -334,7 +334,7 @@ abstract class Client
      *
      * @throws \Exception
      */
-    public function getHTML(string $file, callable $callback = null, bool $append = true): ?string
+    public function getHTML(string $file, ?callable $callback = null, bool $append = true): ?string
     {
         if(!is_null($callback))
         {
@@ -349,7 +349,7 @@ abstract class Client
      *
      * @throws \Exception
      */
-    public function getXHTML(string $file, callable $callback = null, bool $append = true): ?string
+    public function getXHTML(string $file, ?callable $callback = null, bool $append = true): ?string
     {
         if(!is_null($callback))
         {
@@ -364,7 +364,7 @@ abstract class Client
      *
      * @throws \Exception
      */
-    public function getText(string $file, callable $callback = null, bool $append = true): ?string
+    public function getText(string $file, ?callable $callback = null, bool $append = true): ?string
     {
         if(!is_null($callback))
         {
@@ -379,7 +379,7 @@ abstract class Client
      *
      * @throws \Exception
      */
-    public function getMainText(string $file, callable $callback = null, bool $append = true): ?string
+    public function getMainText(string $file, ?callable $callback = null, bool $append = true): ?string
     {
         if(!is_null($callback))
         {
@@ -525,7 +525,7 @@ abstract class Client
      *
      * @throws \Exception
      */
-    public function checkRequest(string $type, string $file = null): ?string
+    public function checkRequest(string $type, ?string $file = null): ?string
     {
         // no checks for getters
         if(in_array($type, ['detectors', 'mime-types', 'parsers', 'version']))
@@ -685,5 +685,5 @@ abstract class Client
      *
      * @throws \Exception
      */
-    abstract public function request(string $type, string $file = null): ?string;
+    abstract public function request(string $type, ?string $file = null): ?string;
 }

--- a/src/Clients/CLIClient.php
+++ b/src/Clients/CLIClient.php
@@ -50,7 +50,7 @@ class CLIClient extends Client
      *
      * @throws \Exception
      */
-    public function __construct(string $path = null, string $java = null, bool $check = true)
+    public function __construct(?string $path = null, string $java = null, bool $check = true)
     {
         parent::__construct();
 
@@ -308,7 +308,7 @@ class CLIClient extends Client
      *
      * @throws \Exception
      */
-    public function request(string $type, string $file = null): string
+    public function request(string $type, ?string $file = null): string
     {
         // check if not checked
         $this->check();
@@ -418,7 +418,7 @@ class CLIClient extends Client
      *
      * @throws  Exception
      */
-    protected function getArguments(string $type, string $file = null): array
+    protected function getArguments(string $type, ?string $file = null): array
     {
         $arguments = $this->encoding ? ["--encoding={$this->encoding}"] : [];
 

--- a/src/Clients/WebClient.php
+++ b/src/Clients/WebClient.php
@@ -77,7 +77,7 @@ class WebClient extends Client
      *
      * @throws \Exception
      */
-    public function __construct(string $host = null, int $port = null, array $options = [], bool $check = true)
+    public function __construct(?string $host = null, ?int $port = null, array $options = [], bool $check = true)
     {
         parent::__construct();
 
@@ -490,7 +490,7 @@ class WebClient extends Client
      *
      * @throws \Exception
      */
-    public function request(string $type, string $file = null): string
+    public function request(string $type, ?string $file = null): string
     {
         static $retries = [];
 
@@ -602,7 +602,7 @@ class WebClient extends Client
      *
      * @throws \Exception
      */
-    protected function error(int $status, string $resource, string $file = null): void
+    protected function error(int $status, string $resource, ?string $file = null): void
     {
         switch($status)
         {
@@ -648,7 +648,7 @@ class WebClient extends Client
      * @link https://wiki.apache.org/tika/TikaJAXRS#Specifying_a_URL_Instead_of_Putting_Bytes
      * @throws \Exception
      */
-    protected function getParameters(string $type, string $file = null): array
+    protected function getParameters(string $type, ?string $file = null): array
     {
         $headers = [];
         $callback = null;
@@ -728,7 +728,7 @@ class WebClient extends Client
      *
      * @throws \Exception
      */
-    protected function getCurlOptions(string $type, string $file = null): array
+    protected function getCurlOptions(string $type, ?string $file = null): array
     {
         // base options
         $options = $this->options;


### PR DESCRIPTION
Hello,
using the library on PHP 8.4 I got few deprecations warnings about Implicitly nullable parameters that is deprecated.

I fixed it

Here is an example of deprecation warnings I catched on logs.

```
PHP Deprecated:  Vaites\ApacheTika\Client::make(): Implicitly marking parameter $param1 as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/vaites/php-apache-tika/src/Client.php on line 112
PHP Deprecated:  Vaites\ApacheTika\Client::getHTML(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/vaites/php-apache-tika/src/Client.php on line 337
PHP Deprecated:  Vaites\ApacheTika\Client::getXHTML(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/vaites/php-apache-tika/src/Client.php on line 352
PHP Deprecated:  Vaites\ApacheTika\Client::getText(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/vaites/php-apache-tika/src/Client.php on line 367
PHP Deprecated:  Vaites\ApacheTika\Client::getMainText(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/vaites/php-apache-tika/src/Client.php on line 382
PHP Deprecated:  Vaites\ApacheTika\Client::checkRequest(): Implicitly marking parameter $file as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/vaites/php-apache-tika/src/Client.php on line 528
PHP Deprecated:  Vaites\ApacheTika\Client::request(): Implicitly marking parameter $file as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/vaites/php-apache-tika/src/Client.php on line 688
PHP Deprecated:  Vaites\ApacheTika\Clients\WebClient::__construct(): Implicitly marking parameter $host as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/vaites/php-apache-tika/src/Clients/WebClient.php on line 80
PHP Deprecated:  Vaites\ApacheTika\Clients\WebClient::__construct(): Implicitly marking parameter $port as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/vaites/php-apache-tika/src/Clients/WebClient.php on line 80
PHP Deprecated:  Vaites\ApacheTika\Clients\WebClient::request(): Implicitly marking parameter $file as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/vaites/php-apache-tika/src/Clients/WebClient.php on line 493
PHP Deprecated:  Vaites\ApacheTika\Clients\WebClient::error(): Implicitly marking parameter $file as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/vaites/php-apache-tika/src/Clients/WebClient.php on line 605
PHP Deprecated:  Vaites\ApacheTika\Clients\WebClient::getParameters(): Implicitly marking parameter $file as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/vaites/php-apache-tika/src/Clients/WebClient.php on line 651
PHP Deprecated:  Vaites\ApacheTika\Clients\WebClient::getCurlOptions(): Implicitly marking parameter $file as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/vaites/php-apache-tika/src/Clients/WebClient.php on line 731

```